### PR TITLE
Adds last edited by field to henvendelse API

### DIFF
--- a/Api/henvendelse_api.json
+++ b/Api/henvendelse_api.json
@@ -735,6 +735,11 @@
                         "description": "Definerer om henvendelsen er markert som kontorsperret. Markeringsinformasjon finnes i listen av markeringer",
                         "example": false
                     },
+                    "sistEndretAv": {
+                        "type": "string",
+                        "description": "Identen til den siste som gjorde endring på tråden.",
+                        "example": "Z994035"
+                    },
                     "sladding": {
                         "type": "boolean",
                         "description": "Definerer om henvendelsen skal vurderes for sladding. Dette sender henvendelsen til en sladdekø",

--- a/force-app/main/default/API/classes/RestServices/API-wrappers/CRM_Henvendelse.cls
+++ b/force-app/main/default/API/classes/RestServices/API-wrappers/CRM_Henvendelse.cls
@@ -5,6 +5,7 @@ global class CRM_Henvendelse extends CRM_HenvendelseApiUtils implements Comparab
     global String avsluttetDato;
     global String opprettetDato;
     global Boolean kontorsperre;
+    global String sistEndretAv;
     global Boolean sladding;
     global Boolean feilsendt;
     global String kjedeId;
@@ -119,13 +120,16 @@ global class CRM_Henvendelse extends CRM_HenvendelseApiUtils implements Comparab
         this.henvendelseId = thread.CRM_HenvendelseId__c;
         this.fnr = thread.CRM_External_Person_Ident_Formula__c;
         this.aktorId = thread.CRM_External_ActorId_Formula__c;
+        this.sistEndretAv = thread.CRM_Last_Edited_By__c;
         this.opprinneligGT = thread.CRM_Original_Person_GT__c;
         this.opprinneligEnhet = thread.CRM_Original_Person_NAV_Unit__c;
         this.kasseringsDato = formatDateTime(thread.CRM_Disposal_Datetime__c);
         this.opprettetDato = formatDateTime(thread.CRM_Date_Time_Registered__c);
         this.avsluttetDato = formatDateTime(thread.CRM_Closed_Date__c);
         this.meldinger = new List<CRM_Melding>();
-        this.henvendelseType = (thread.CRM_Type__c == 'CHAT') ? HENVENDELSE_TYPE.CHAT.name() : HENVENDELSE_TYPE.MELDINGSKJEDE.name();
+        this.henvendelseType = (thread.CRM_Type__c == 'CHAT')
+            ? HENVENDELSE_TYPE.CHAT.name()
+            : HENVENDELSE_TYPE.MELDINGSKJEDE.name();
         this.gjeldendeTemagruppe = thread.CRM_Theme_Group_Code__c;
         this.gjeldendeTema = thread.CRM_Theme_Code__c;
         this.sladding = thread.STO_Sensitive_Information__c;

--- a/force-app/main/default/API/classes/RestServices/Selectors/CRM_ThreadSelector.cls
+++ b/force-app/main/default/API/classes/RestServices/Selectors/CRM_ThreadSelector.cls
@@ -8,6 +8,7 @@ public with sharing class CRM_ThreadSelector extends CRM_ApiSelector {
             Thread__c.CRM_isActive__c,
             Thread__c.CRM_Date_Time_Registered__c,
             Thread__c.CRM_Office_Restriction__c,
+            Thread__c.CRM_Last_edited_by__c,
             Thread__c.Id,
             Thread__c.CRM_HenvendelseId__c,
             Thread__c.Name,


### PR DESCRIPTION
Relatert til:
https://jira.adeo.no/browse/FAGSYSTEM-291504
https://jira.adeo.no/browse/FAGSYSTEM-291924

Vi hadde et møte med Modia nå og løser dette ved å legge til Thread__c.CRM_Last_edited_by__c i henvendelses-apiet slik at de kan bruke dette feltet.
Vanligvis setter de bare den som sendte sist melding som den som lukker om saken lukkes, men i dette tilfellet var det bare en saksbehandler som lukket uten å sende melding, og da ble den med siste stående melding satt som den som lukket istedenfor den som faktisk lukket. Ved å legge til Thread__c.CRM_Last_edited_by__c vil de bruke dette istedenfor ved lukking.