### PR TITLE
Remove documentation id

### DIFF
--- a/force-app/main/default/classes/ArchiveBatch.cls
+++ b/force-app/main/default/classes/ArchiveBatch.cls
@@ -8,9 +8,11 @@
 public with sharing class ArchiveBatch implements Database.Batchable<SObject>, Database.AllowsCallouts, Schedulable {
     private String domain;
     private LoggerUtility logger;
+    CRM_ApplicationDomain myDomain = new CRM_ApplicationDomain();
+    Map<String, CRM_ApplicationDomain.Domain> domainNameMap = myDomain.domainNameMap;
 
     public ArchiveBatch(String domain) {
-        this.domain = domain;
+        this.domain = domain != null ? domain.toUpperCase() : '';
         this.logger = new LoggerUtility(domain);
     }
 
@@ -31,7 +33,6 @@ public with sharing class ArchiveBatch implements Database.Batchable<SObject>, D
     }
 
     public void execute(Database.BatchableContext BC, List<Archive_Entry__c> scope) {
-        // Collect data for callouts
         List<ArchiveRequestWrapper> archiveRecordsToPost = new List<ArchiveRequestWrapper>();
         for (Archive_Entry__c archiveEntry : scope) {
             ArchiveRequestWrapper reqWrapper = new ArchiveRequestWrapper(
@@ -52,7 +53,7 @@ public with sharing class ArchiveBatch implements Database.Batchable<SObject>, D
         try {
             response = new ArchiveService().postToArchive(archiveRecordsToPost);
         } catch (Exception e) {
-            logger.error(e.getMessage() + '. ' + e.getStackTraceString(), null, CRM_ApplicationDomain.Domain.NKS);
+            logger.error(e.getMessage() + '. ' + e.getStackTraceString(), null, domainNameMap.get(domain));
         } finally {
             logger.publish();
         }

--- a/force-app/main/default/classes/ArchiveBatch.cls
+++ b/force-app/main/default/classes/ArchiveBatch.cls
@@ -26,7 +26,7 @@ public with sharing class ArchiveBatch implements Database.Batchable<SObject>, D
     }
 
     public Database.QueryLocator start(Database.BatchableContext BC) {
-        String query = 'SELECT Id, Ready_for_Deletion__c, Reference_Object__c, Reference_Id__c, Actor_Id__c, Confidential__c, Documentation_Id__c, Domain__c, Fnr__c, Orgnr__c, Status__c, Theme__c, Archive_Data__c FROM Archive_Entry__c WHERE Status__c = \'Failed\' AND Domain__c = :domain';
+        String query = 'SELECT Id, Ready_for_Deletion__c, Reference_Object__c, Reference_Id__c, Actor_Id__c, Confidential__c, Domain__c, Fnr__c, Orgnr__c, Status__c, Theme__c, Archive_Data__c FROM Archive_Entry__c WHERE Status__c = \'Failed\' AND Domain__c = :domain';
         return Database.getQueryLocator(query);
     }
 

--- a/force-app/main/default/classes/ArchiveHandler.cls
+++ b/force-app/main/default/classes/ArchiveHandler.cls
@@ -29,11 +29,11 @@ public inherited sharing class ArchiveHandler {
             return null;
         }
 
-        List<String> documentationIdResponses = new List<String>(); // The API returns id attribute on success
+        List<String> responseIds = new List<String>(); // The API returns id attribute on success
         for (ArchiveService.ArchiveResponseWrapper archiveResponse : response) {
-            documentationIdResponses.add(String.valueOf(archiveResponse.id));
+            responseIds.add(String.valueOf(archiveResponse.id));
         }
-        return documentationIdResponses;
+        return responseIds;
     }
 
     public class ArchivePostWrapper {
@@ -52,7 +52,7 @@ public inherited sharing class ArchiveHandler {
         @invocableVariable(required=true)
         public Boolean konfidentiellt;
         @invocableVariable
-        public String dokumentasjonId;
+        public String dokumentasjonId; // Reference_Id__c
         @invocableVariable
         public String referenceObject;
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,7 +9,7 @@
             "dependencies": [
                 {
                     "package": "crm-platform-base",
-                    "versionNumber": "0.209.0.LATEST"
+                    "versionNumber": "0.210.0.LATEST"
                 },
                 {
                     "package": "crm-henvendelse-base",


### PR DESCRIPTION
Documentation Id is only used in requests to Arkiv (it is reference_id__c). We do not need to store it in SF.