### PR TITLE
Servicetjenesten sladding

### DIFF
--- a/force-app/main/default/flexipages/Sladding_Home_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Sladding_Home_Page.flexipage-meta.xml
@@ -50,6 +50,49 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>filterName</name>
+                    <value>Thread_ListView_STO_Servicetjenesten</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>hideActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>hideSearchBar</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>pageSize</name>
+                    <value>3</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:filterListCard</componentName>
+                <identifier>flexipage_filterListCard10</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.UserRole.Name}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>HOT</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>enableInlineEdit</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>entityName</name>
+                    <value>Thread__c</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>filterName</name>
                     <value>Thread_List_View_BS</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
@@ -67,10 +110,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard1</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>NE</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -178,10 +227,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard4</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -215,10 +270,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard5</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -252,10 +313,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard6</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -289,10 +356,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard7</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -326,10 +399,16 @@
                 <componentName>flexipage:filterListCard</componentName>
                 <identifier>flexipage_filterListCard8</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 AND 2</booleanFilter>
                     <criteria>
                         <leftValue>{!$User.UserRole.Name}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>HOT</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!$User.Profile.Name}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>HOT Servicetjenesten</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>

--- a/force-app/main/default/objects/Thread__c/listViews/Thread_ListView_STO_Servicetjenesten.listView-meta.xml
+++ b/force-app/main/default/objects/Thread__c/listViews/Thread_ListView_STO_Servicetjenesten.listView-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Thread_ListView_STO_Servicetjenesten</fullName>
+    <columns>NAME</columns>
+    <columns>CRM_Thread_Type__c</columns>
+    <columns>STO_Category__c</columns>
+    <columns>STO_Sensitive_Information_Date__c</columns>
+    <columns>Cause__c</columns>
+    <columns>Journaled__c</columns>
+    <filterScope>Everything</filterScope>
+    <filters>
+        <field>STO_Sensitive_Information__c</field>
+        <operation>equals</operation>
+        <value>1</value>
+    </filters>
+    <filters>
+        <field>STO_Category__c</field>
+        <operation>equals</operation>
+        <value>Hjelpemidler</value>
+    </filters>
+    <label>Samletråder STO Servicetjenesten</label>
+</ListView>


### PR DESCRIPTION
Legger til STO fra Servicetjenesten i ny liste i sladde appen. 

Filtrerer slik at bare brukere med rolle HOT og profil HOT Servicetjenesten kan se den.

Oppdaterer de gamle listene med tråder fra tolk hvor de ikke vises om profil er HOT Servicetjenesten. Fra før vises de kun om det er rolle HOT.