### PR TITLE
Standard Signature for crmMessagingQuickText

### DIFF
--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.css
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.css
@@ -20,3 +20,16 @@
     height: 1px;
     overflow: hidden;
 }
+
+.signature-textarea {
+    resize: none;
+    text-wrap: nowrap;
+}
+.signature-textarea-hidden {
+    resize: none;
+    text-wrap: nowrap;
+    display: none;
+}
+.toolbar-no-padding {
+    padding: 0;
+}

--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.html
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.html
@@ -110,6 +110,26 @@
             >
                 {conversationNote}
             </textarea>
+            <template lwc:if={standardSignature}>
+                <div class="slds-rich-text-editor__toolbar slds-rich-text-editor__toolbar_bottom toolbar-no-padding">
+                    <textarea
+                        class="standardSignature signature-textarea slds-rich-text-editor__textarea slds-grid slds-textarea"
+                        rows="3"
+                        readonly
+                        name="Signatur"
+                    >
+                {standardSignatureText}
+                </textarea
+                    >
+                    <div class="slds-var-p-around_xx-small">
+                        <lightning-checkbox-group
+                            options={checkBoxOptions}
+                            value={checkBoxValue}
+                            onchange={handleCheckBoxChange}
+                        ></lightning-checkbox-group>
+                    </div>
+                </div>
+            </template>
         </div>
     </div>
 </template>

--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js
@@ -269,20 +269,12 @@ export default class CrmQuickText extends LightningElement {
         let noteArea = this.template.querySelector('.conversationNoteTextArea');
         if (event.detail.value.includes('Standard')) {
             this.checkBoxValue = 'Standard';
-            signature.className = signature.className
-                .split(' ')
-                .filter((e) => e !== 'signature-textarea-hidden')
-                .concat('signature-textarea')
-                .join(' ');
+            signature.classList.replace('signature-textarea-hidden', 'signature-textarea');
             noteArea.style.height = noteArea.offsetHeight - signature.offsetHeight + 'px';
         } else {
             this.checkBoxValue = 'Ingen';
             noteArea.style.height = noteArea.offsetHeight + signature.offsetHeight + 'px';
-            signature.className = signature.className
-                .split(' ')
-                .filter((e) => e !== 'signature-textarea')
-                .concat('signature-textarea-hidden')
-                .join(' ');
+            signature.classList.replace('signature-textarea', 'signature-textarea-hidden');
         }
     }
 

--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js
@@ -22,7 +22,9 @@ export default class CrmQuickText extends LightningElement {
     @api required = false;
     @api resetTextTemplate = '';
     @api useForConversationNote = false;
+    @api standardSignature = false;
 
+    checkBoxValue = 'Standard';
     recentlyInserted = '';
     labels = { BLANK_ERROR };
     _conversationNote;
@@ -31,12 +33,20 @@ export default class CrmQuickText extends LightningElement {
     loadingData = false;
     data = [];
     _isOpen = false;
+    _standardSignatureText = '';
 
     renderedCallback() {
         if (this.initialRender) {
             let inputField = this.textArea;
             inputField.focus();
             inputField.blur();
+
+            if (this.standardSignature === true) {
+                let signature = this.template.querySelector('.standardSignature');
+                let noteArea = this.template.querySelector('.conversationNoteTextArea');
+                noteArea.style.height = noteArea.offsetHeight - signature.offsetHeight + 'px';
+            }
+
             this.initialRender = false;
         }
     }
@@ -254,6 +264,28 @@ export default class CrmQuickText extends LightningElement {
         }
     }
 
+    handleCheckBoxChange(event) {
+        let signature = this.template.querySelector('.standardSignature');
+        let noteArea = this.template.querySelector('.conversationNoteTextArea');
+        if (event.detail.value.includes('Standard')) {
+            this.checkBoxValue = 'Standard';
+            signature.className = signature.className
+                .split(' ')
+                .filter((e) => e !== 'signature-textarea-hidden')
+                .concat('signature-textarea')
+                .join(' ');
+            noteArea.style.height = noteArea.offsetHeight - signature.offsetHeight + 'px';
+        } else {
+            this.checkBoxValue = 'Ingen';
+            noteArea.style.height = noteArea.offsetHeight + signature.offsetHeight + 'px';
+            signature.className = signature.className
+                .split(' ')
+                .filter((e) => e !== 'signature-textarea')
+                .concat('signature-textarea-hidden')
+                .join(' ');
+        }
+    }
+
     _getQmappedItem(abbreviation) {
         for (const item of this.qmap) {
             if (item.abbreviation.toUpperCase() !== item.content.message) {
@@ -387,7 +419,23 @@ export default class CrmQuickText extends LightningElement {
     set conversationNoteRich(value) {
         this._conversationNote = value;
     }
-
+    @api
+    get conversationNoteWithSignature() {
+        if (this.standardSignature === true && this.checkBoxValue === 'Standard' && this.standardSignatureText !== '') {
+            return this.conversationNote + '\n\n' + this.standardSignatureText;
+        }
+        return this.conversationNote;
+    }
+    set conversationNoteWithSignature(value) {
+        //readonly
+    }
+    @api
+    get standardSignatureText() {
+        return this._standardSignatureText;
+    }
+    set standardSignatureText(value) {
+        this._standardSignatureText = value;
+    }
     get cssClass() {
         const baseClasses = ['slds-modal'];
         baseClasses.push([this.isOpen ? 'slds-visible slds-fade-in-open' : 'slds-hidden']);
@@ -404,5 +452,8 @@ export default class CrmQuickText extends LightningElement {
 
     get placeHolderText() {
         return this.useForConversationNote ? '' : 'Skriv melding her';
+    }
+    get checkBoxOptions() {
+        return [{ label: 'Standard signatur', value: 'Standard' }];
     }
 }

--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js-meta.xml
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js-meta.xml
@@ -8,7 +8,7 @@
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
             <property name="conversationNote" type="String" label="Conversation Note Output"
-                role="OutputOnly" />
+                role="outputOnly" />
             <property name="conversationNoteRich" type="String" label="Conversation Note Input" />
             <property name="required" type="Boolean" label="Required" default="false"
                 role="inputOnly" />

--- a/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js-meta.xml
+++ b/force-app/main/default/lwc/crmMessagingQuickText/crmMessagingQuickText.js-meta.xml
@@ -15,6 +15,13 @@
             <property name="comments" type="String" label="Comments" />
             <property name="useForConversationNote" type="Boolean" label="Use for conversation note"
                 default="false" role="inputOnly" />
+            <property name="standardSignature" type="Boolean"
+                label="Show standard signature" default="false"
+                role="inputOnly" />
+            <property name="standardSignatureText" type="String"
+                label="Signature template" default=""/>
+            <property name="conversationNoteWithSignature" type="String" label="Conversation Note With Signature Output"
+                role="outputOnly" />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
Added functionality for standard signature
<img width="432" alt="image" src="https://github.com/user-attachments/assets/12c2d99c-5c58-4374-8444-6be805b4917f" />
This can be controlled by these properies in flow:
<img width="310" alt="image" src="https://github.com/user-attachments/assets/3d693029-8877-4f4d-95d4-e97b3557b9c8" />
