### PR TITLE
Remove duplicate parameter, fix invalid schema

### DIFF
--- a/Api/henvendelse_api.json
+++ b/Api/henvendelse_api.json
@@ -136,7 +136,6 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
                                     "$ref": "#/components/schemas/Henvendelse"
                                 }
                             }
@@ -188,7 +187,6 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
                                     "$ref": "#/components/schemas/Henvendelse"
                                 }
                             }
@@ -222,9 +220,6 @@
                             "type": "string"
                         },
                         "description": "Unik kjedeId til meldingstråden som skal lukkes"
-                    },
-                    {
-                        "$ref": "#/components/parameters/X-Correlation-ID"
                     },
                     {
                         "name": "aktorid",
@@ -286,7 +281,6 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
                                     "$ref": "#/components/schemas/Henvendelse"
                                 }
                             }


### PR DESCRIPTION
X-Correlation-ID is listed twice. It is not a valid openAPI spec.
