### PR TITLE
Remove journalforerNavIdent as required property.

### DIFF
--- a/Api/henvendelse_api.json
+++ b/Api/henvendelse_api.json
@@ -680,7 +680,7 @@
                         "example": "509934220"
                     }
                 },
-                "required": ["journalforerNavIdent", "journalfortDato", "journalfortTema"]
+                "required": ["journalfortDato", "journalfortTema"]
             },
             "MeldingFra": {
                 "type": "object",


### PR DESCRIPTION
Deserialisering feiler i dev for oss i modiapersonoversikt ettersom det finnes meldinger uten denne attributten, så den kan være null i noen tilfeller.